### PR TITLE
Should use Unicode encoding for content of SMS for Nexmo

### DIFF
--- a/lib/sms_center/nexmo.rb
+++ b/lib/sms_center/nexmo.rb
@@ -8,7 +8,8 @@ class SmsCenter::Nexmo
       api_secret: keys[:NEXMO_API_SECRET],
       to: to_number,
       text: content,
-      from: from_number
+      from: from_number,
+      type: 'unicode'
     }
   end
 end

--- a/sms_center.gemspec
+++ b/sms_center.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name                  = 'sms_center'
-  s.version               = '0.0.13'
-  s.date                  = '2020-02-11'
+  s.version               = '0.0.14'
+  s.date                  = '2021-09-30'
   s.summary               = 'Deliveree!'
   s.description           = 'A simple tool to using SMS third party'
   s.authors               = ['Deleveree']


### PR DESCRIPTION
https://help.nexmo.com/hc/en-us/articles/205704358-Why-do-I-see-question-marks-in-my-SMS-message-instead-of-the-original-characters-